### PR TITLE
Add works and about sections to portfolio

### DIFF
--- a/src/app/components/About/About.styles.ts
+++ b/src/app/components/About/About.styles.ts
@@ -1,0 +1,7 @@
+export const styles = {
+  wrapper: () => 'py-16 bg-white text-gray-900',
+  container: () => 'max-w-3xl mx-auto flex flex-col items-center text-center space-y-6 px-6',
+  image: () => 'rounded-full',
+  heading: () => 'text-3xl font-bold',
+  text: () => 'text-gray-600 leading-relaxed',
+};

--- a/src/app/components/About/About.tsx
+++ b/src/app/components/About/About.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image';
+import { styles } from './About.styles';
+
+export default function About() {
+  return (
+    <section id="about" className={styles.wrapper()}>
+      <div className={styles.container()}>
+        <Image
+          src="/next.svg"
+          alt="Profile"
+          width={120}
+          height={120}
+          className={styles.image()}
+        />
+        <h2 className={styles.heading()}>About Me</h2>
+        <p className={styles.text()}>
+          フロントエンドとバックエンドを行き来する開発者。UIデザインと高品質なコードが好きです。
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/Works/Works.styles.ts
+++ b/src/app/components/Works/Works.styles.ts
@@ -1,0 +1,9 @@
+export const styles = {
+  wrapper: () => 'py-16 bg-gray-100 text-gray-900',
+  heading: () => 'text-3xl font-bold text-center mb-10',
+  grid: () => 'max-w-5xl mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 px-6',
+  item: () => 'bg-white p-6 rounded-lg shadow hover:shadow-lg transition-shadow flex flex-col items-center text-center space-y-4',
+  image: () => 'w-24 h-24',
+  title: () => 'text-xl font-semibold',
+  description: () => 'text-sm text-gray-500',
+};

--- a/src/app/components/Works/Works.tsx
+++ b/src/app/components/Works/Works.tsx
@@ -1,0 +1,43 @@
+import Image from 'next/image';
+import { styles } from './Works.styles';
+
+const works = [
+  {
+    src: '/window.svg',
+    title: 'Window App',
+    description: 'デスクトップUIのような操作感を持つWebアプリケーションです。'
+  },
+  {
+    src: '/globe.svg',
+    title: 'Globe Project',
+    description: '世界中の情報を可視化するインタラクティブな地図アプリ。'
+  },
+  {
+    src: '/file.svg',
+    title: 'File Manager',
+    description: 'シンプルで直感的なファイル管理ツール。'
+  }
+];
+
+export default function Works() {
+  return (
+    <section id="works" className={styles.wrapper()}>
+      <h2 className={styles.heading()}>Works</h2>
+      <div className={styles.grid()}>
+        {works.map((work) => (
+          <div key={work.title} className={styles.item()}>
+            <Image
+              src={work.src}
+              alt={work.title}
+              width={96}
+              height={96}
+              className={styles.image()}
+            />
+            <h3 className={styles.title()}>{work.title}</h3>
+            <p className={styles.description()}>{work.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,13 +5,6 @@
   --foreground: #171717;
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "./components/Header/Header";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -25,9 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         <Header />
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,14 @@
 import Hero from "./components/Hero/Hero";
+import Works from "./components/Works/Works";
+import About from "./components/About/About";
 
 export default function Home() {
   return (
     <>
       <Hero />
-      {/* 後続のセクション（Works, About, Contactなど） */}
+      <Works />
+      <About />
+      {/* 後続のセクション（Contactなど） */}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Showcase projects with a new Works section displaying local SVG images.
- Introduce an About section with a profile image and description.
- Simplify layout and global styles by removing external font dependencies.

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c5622cdf483259d69d0d6bd0085a6